### PR TITLE
Add History section visibility settings

### DIFF
--- a/frontend/src/components/History.jsx
+++ b/frontend/src/components/History.jsx
@@ -1,13 +1,16 @@
-import React from 'react';
-import { Box, Typography } from '@mui/material';
+import React, { useState } from 'react';
+import { Box, Typography, IconButton } from '@mui/material';
 import RecordList from './RecordList';
 import RecordHeatmap from './RecordHeatmap';
 import RecordCalendar from './RecordCalendar';
 import RecordChart from './RecordChart';
 import { useUI } from '../contexts/UIContext';
+import SettingsIcon from '@mui/icons-material/Settings';
+import HistoryDisplayDialog from './HistoryDisplayDialog';
 
 function History() {
-    const { dispatch: uiDispatch } = useUI();
+    const { state: uiState, dispatch: uiDispatch } = useUI();
+    const [settingsOpen, setSettingsOpen] = useState(false);
     return (
         <Box sx={{ mb: 2 }}>
             {/* Heading / Title */}
@@ -51,11 +54,16 @@ function History() {
                 >
                     Close All
                 </Typography>
+                <Box sx={{ flexGrow: 1 }} />
+                <IconButton size="small" onClick={() => setSettingsOpen(true)}>
+                    <SettingsIcon fontSize='small' />
+                </IconButton>
             </Box>
-            <RecordChart />
-            <RecordHeatmap />
-            <RecordCalendar />
-            <RecordList />
+            {uiState.showChart && <RecordChart />}
+            {uiState.showHeatmap && <RecordHeatmap />}
+            {uiState.showCalendar && <RecordCalendar />}
+            {uiState.showRecords && <RecordList />}
+            <HistoryDisplayDialog open={settingsOpen} onClose={() => setSettingsOpen(false)} />
         </Box>
     );
 }

--- a/frontend/src/components/HistoryDisplayDialog.jsx
+++ b/frontend/src/components/HistoryDisplayDialog.jsx
@@ -1,0 +1,101 @@
+import React, { useState, useEffect } from 'react';
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    FormControlLabel,
+    Switch,
+    Stack,
+    Divider,
+    Box,
+} from '@mui/material';
+import { useUI } from '../contexts/UIContext';
+
+const DEFAULT_VISIBILITY = {
+    showChart: true,
+    showHeatmap: true,
+    showCalendar: true,
+    showRecords: true,
+};
+
+function HistoryDisplayDialog({ open, onClose }) {
+    const { state: uiState, dispatch: uiDispatch } = useUI();
+
+    const [tmpShowChart, setTmpShowChart] = useState(uiState.showChart);
+    const [tmpShowHeatmap, setTmpShowHeatmap] = useState(uiState.showHeatmap);
+    const [tmpShowCalendar, setTmpShowCalendar] = useState(uiState.showCalendar);
+    const [tmpShowRecords, setTmpShowRecords] = useState(uiState.showRecords);
+
+    useEffect(() => {
+        if (open) {
+            setTmpShowChart(uiState.showChart);
+            setTmpShowHeatmap(uiState.showHeatmap);
+            setTmpShowCalendar(uiState.showCalendar);
+            setTmpShowRecords(uiState.showRecords);
+        }
+    }, [open, uiState]);
+
+    const handleReset = () => {
+        setTmpShowChart(DEFAULT_VISIBILITY.showChart);
+        setTmpShowHeatmap(DEFAULT_VISIBILITY.showHeatmap);
+        setTmpShowCalendar(DEFAULT_VISIBILITY.showCalendar);
+        setTmpShowRecords(DEFAULT_VISIBILITY.showRecords);
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="sm">
+            <DialogTitle>History Items</DialogTitle>
+
+            <DialogContent dividers>
+                <Stack spacing={3} divider={<Divider flexItem />}>
+                    <FormControlLabel
+                        control={<Switch checked={tmpShowChart} onChange={e => setTmpShowChart(e.target.checked)} />}
+                        label="Show Chart"
+                    />
+                    <FormControlLabel
+                        control={<Switch checked={tmpShowHeatmap} onChange={e => setTmpShowHeatmap(e.target.checked)} />}
+                        label="Show Heatmap"
+                    />
+                    <FormControlLabel
+                        control={<Switch checked={tmpShowCalendar} onChange={e => setTmpShowCalendar(e.target.checked)} />}
+                        label="Show Calendar"
+                    />
+                    <FormControlLabel
+                        control={<Switch checked={tmpShowRecords} onChange={e => setTmpShowRecords(e.target.checked)} />}
+                        label="Show Records"
+                    />
+                </Stack>
+            </DialogContent>
+
+            <DialogActions>
+                <Button onClick={handleReset} color="inherit" sx={{ mr: 'auto', textTransform: 'none' }}>
+                    Reset to Defaults
+                </Button>
+                <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>
+                    <Button onClick={onClose}>Cancel</Button>
+                    <Button
+                        variant="contained"
+                        onClick={() => {
+                            uiDispatch({
+                                type: 'UPDATE_UI',
+                                payload: {
+                                    showChart: tmpShowChart,
+                                    showHeatmap: tmpShowHeatmap,
+                                    showCalendar: tmpShowCalendar,
+                                    showRecords: tmpShowRecords,
+                                },
+                            });
+                            onClose();
+                        }}
+                    >
+                        Apply
+                    </Button>
+                </Box>
+            </DialogActions>
+        </Dialog>
+    );
+}
+
+export default HistoryDisplayDialog;

--- a/frontend/src/reducers/uiReducer.js
+++ b/frontend/src/reducers/uiReducer.js
@@ -12,6 +12,10 @@ export const initialUIState = {
     heatmapOpen: true,
     calendarOpen: true,
     recordsOpen: true,
+    showChart: true,
+    showHeatmap: true,
+    showCalendar: true,
+    showRecords: true,
 };
 
 export function uiReducer(state, action) {
@@ -44,6 +48,15 @@ export function uiReducer(state, action) {
             return { ...state, calendarOpen: action.payload };
         case 'SET_RECORDS_OPEN':
             return { ...state, recordsOpen: action.payload };
+        // History項目の表示有無
+        case 'SET_SHOW_CHART':
+            return { ...state, showChart: action.payload };
+        case 'SET_SHOW_HEATMAP':
+            return { ...state, showHeatmap: action.payload };
+        case 'SET_SHOW_CALENDAR':
+            return { ...state, showCalendar: action.payload };
+        case 'SET_SHOW_RECORDS':
+            return { ...state, showRecords: action.payload };
         // 一括変更
         case 'UPDATE_UI':
             return { ...state, ...action.payload };


### PR DESCRIPTION
## Summary
- allow toggling visibility of Chart, Heatmap, Calendar and Records
- store new visibility settings in `uiState`
- provide `HistoryDisplayDialog` with reset-to-defaults
- wire dialog to History header via a settings button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6878f12fff44832981ba366b7c318cde