### PR TITLE
Add daily averages to Trend totals

### DIFF
--- a/frontend/src/components/RecordTrend.jsx
+++ b/frontend/src/components/RecordTrend.jsx
@@ -106,7 +106,7 @@ function formatDailyAverage(total, unit, days) {
     if (unit === 'minutes') {
         const hours = Math.floor(avg / 60);
         const minutes = Math.floor(avg % 60);
-        return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}/d`;
+        return `${String(hours)}:${String(minutes).padStart(2, '0')}/d`;
     }
     return `${avg}/d`;
 }


### PR DESCRIPTION
## Summary
- show average per day beneath Totals in Trend tables
- compute daily average from Date Range and format as hh:mm/d

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run -w frontend lint` *(fails: 172 problems, command sh -c eslint .)*

------
https://chatgpt.com/codex/tasks/task_e_68a32519d34083299560b41bdbf9302c