### PR TITLE
Add daily averages to Trend totals

### DIFF
--- a/frontend/src/components/RecordTrend.jsx
+++ b/frontend/src/components/RecordTrend.jsx
@@ -107,7 +107,7 @@ function formatDailyAverage(total, unit, days) {
         const rounded = Math.round(avg);
         const hours = Math.floor(rounded / 60);
         const minutes = Math.floor(rounded % 60);
-        return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}/d`;
+        return `${String(hours)}:${String(minutes).padStart(2, '0')}/d`;
     }
     if (unit === 'count') {
         return `${avg.toFixed(1)}/d`;


### PR DESCRIPTION
## Summary
- show average per day beneath Totals in Trend tables
- compute daily average from Date Range and format as hh:mm/d
- center Total column and widen Total/Change columns
- display count-unit daily averages with one decimal

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run -w frontend lint` *(fails: command sh -c eslint .)*

------
https://chatgpt.com/codex/tasks/task_e_68a32519d34083299560b41bdbf9302c