### PR TITLE
fix: resolve lint errors in frontend

### DIFF
--- a/frontend/src/contexts/UIContext.jsx
+++ b/frontend/src/contexts/UIContext.jsx
@@ -1,4 +1,5 @@
-import React, { createContext, useContext } from 'react';
+import { createContext, useContext } from 'react';
+import PropTypes from 'prop-types';
 import { initialUIState, uiReducer } from '../reducers/uiReducer';
 import usePersistentReducer from '../hooks/usePersistentReducer';
 
@@ -18,4 +19,9 @@ export const UIProvider = ({ children }) => {
   );
 };
 
+UIProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
 export const useUI = () => useContext(UIContext);
+

--- a/frontend/src/utils/getIconForGroup.jsx
+++ b/frontend/src/utils/getIconForGroup.jsx
@@ -1,18 +1,17 @@
-import React from 'react';
 import iconMapping from './iconMapping';
 
 const getIconForGroup = (group, groups) => {
   const currentGroup = groups.find(g => g.name === group);
-  const customIconName = (currentGroup && currentGroup.icon_name) ? currentGroup.icon_name : 'HomeWorkIcon';
-  const customIconColor = (currentGroup && currentGroup.icon_color) ? currentGroup.icon_color : 'gray';
+  const customIconName = currentGroup?.icon_name || 'HomeWorkIcon';
+  const customIconColor = currentGroup?.icon_color || 'gray';
 
   if (customIconName && iconMapping[customIconName]) {
     const IconComponent = iconMapping[customIconName];
     return <IconComponent sx={{ mr: 1, color: customIconColor }} />;
-  } else {
-    const DefaultIcon = iconMapping.HomeWorkIcon;
-    return <DefaultIcon sx={{ mr: 1, color: 'gray' }} />;
   }
+
+  const DefaultIcon = iconMapping.HomeWorkIcon;
+  return <DefaultIcon sx={{ mr: 1, color: 'gray' }} />;
 };
 
 export default getIconForGroup;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process */
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { version } from '../package.json'
@@ -25,3 +27,4 @@ export default defineConfig({
         __COMMIT_HASH__: JSON.stringify(process.env.VITE_COMMIT_HASH || 'dev'),
     },
 })
+


### PR DESCRIPTION
## Summary
- remove unused React import and streamline group icon helper
- add PropTypes validation for UI context provider
- clarify node globals in Vite config

## Testing
- `npx eslint src/utils/getIconForGroup.jsx src/contexts/UIContext.jsx vite.config.js`

------
https://chatgpt.com/codex/tasks/task_e_68a32ec938748329b74d0fc1c0ac2901