### PR TITLE
集計除外グループをGroup選択から非表示にする

### DIFF
--- a/frontend/src/components/ActivityStart.jsx
+++ b/frontend/src/components/ActivityStart.jsx
@@ -108,6 +108,26 @@ function ActivityStart({
     const [showRemaining, setShowRemaining] = useState(false);
     const [showArchive, setShowArchive] = useState(false);
 
+    const selectableGroups = useMemo(() => {
+        return groups.filter((group) => !excludedGroupIds.has(Number(group.id)));
+    }, [groups, excludedGroupIds]);
+
+    useEffect(() => {
+        if (!groupFilter) return;
+
+        const selectedGroup = groups.find((group) => group.name === groupFilter);
+        if (!selectedGroup) return;
+        if (!excludedGroupIds.has(Number(selectedGroup.id))) return;
+
+        // 除外されたグループが選択中なら、表示可能な状態に戻す
+        setFilterState((prev) => ({
+            ...prev,
+            groupFilter: '',
+            activityNameFilter: '',
+            tagFilter: '',
+        }));
+    }, [groupFilter, groups, excludedGroupIds, setFilterState]);
+
     // アクティビティに対するフィルターの適用
     const filteredActivities = activities.filter(act => {
         // グループフィルタ
@@ -292,7 +312,7 @@ function ActivityStart({
                                     >
                                         All
                                     </ToggleButton>
-                                    {groups.map((group) => (
+                                    {selectableGroups.map((group) => (
                                         <ToggleButton
                                             key={group.id}
                                             value={group.name}
@@ -324,7 +344,7 @@ function ActivityStart({
                                     <ToggleButton value="" aria-label="All">
                                         All
                                     </ToggleButton>
-                                    {groups.map((group) => (
+                                    {selectableGroups.map((group) => (
                                         <ToggleButton key={group.id} value={group.name} aria-label={group.name}>
                                             {getIconForGroup(group.name, groups)}
                                             {group.name}


### PR DESCRIPTION
## 概要
Group の「集計除外」が On の場合、そのグループを Group 選択ボタンに表示しないように変更しました。

## 変更内容
- Group 選択用の表示リストから、集計除外対象のグループを除外
- すでに集計除外グループが選択されていた場合は、フィルタを `All` にリセットするよう調整

## 確認内容
- `frontend` で `npm run build` が成功することを確認
- 集計除外を On にしたグループが Group 選択ボタンに表示されないこと
- 集計除外に切り替えたグループを選択中だった場合、表示が `All` に戻ること

## 補足
- ルートの `npm run build` は `pyinstaller` 未導入のため失敗しますが、今回のフロントエンド変更とは無関係です
